### PR TITLE
feat: Immersive loading UX with phase feedback and cost estimate

### DIFF
--- a/src/__tests__/LoadingState.test.tsx
+++ b/src/__tests__/LoadingState.test.tsx
@@ -1,35 +1,76 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import LoadingState from '@/components/LoadingState';
+import LoadingState, { type LoadingPhase } from '@/components/LoadingState';
+
+const now = Date.now();
+
+const activePhases: LoadingPhase[] = [
+  { label: 'Searching the archives...', startTime: now - 3000 },
+  { label: 'Firing up the time machine...', startTime: 0 },
+];
+
+const completedStoryPhases: LoadingPhase[] = [
+  { label: 'Searching the archives...', startTime: now - 6000, endTime: now - 3000 },
+  { label: 'Firing up the time machine...', startTime: now - 3000 },
+];
+
+const allCompletedPhases: LoadingPhase[] = [
+  { label: 'Searching the archives...', startTime: now - 6000, endTime: now - 3000 },
+  { label: 'Firing up the time machine...', startTime: now - 3000, endTime: now },
+];
 
 describe('LoadingState', () => {
-  it('renders default loading text when no message prop', () => {
-    render(<LoadingState />);
-    expect(screen.getByText('Uncovering history...')).toBeInTheDocument();
+  it('renders phase list with correct number of phases', () => {
+    render(<LoadingState phases={activePhases} pipelineStart={now - 3000} />);
+    const phaseList = screen.getByTestId('phase-list');
+    expect(phaseList.children.length).toBe(2);
   });
 
-  it('renders custom message when provided', () => {
-    render(<LoadingState message="Finding our history professor..." />);
-    expect(screen.getByText('Finding our history professor...')).toBeInTheDocument();
-    expect(screen.queryByText('Uncovering history...')).not.toBeInTheDocument();
+  it('renders phase labels', () => {
+    render(<LoadingState phases={activePhases} pipelineStart={now - 3000} />);
+    expect(screen.getByText('Searching the archives...')).toBeInTheDocument();
+    expect(screen.getByText('Firing up the time machine...')).toBeInTheDocument();
   });
 
   it('renders skeleton lines', () => {
-    const { container } = render(<LoadingState />);
+    const { container } = render(<LoadingState phases={activePhases} pipelineStart={now} />);
     const skeletonLines = container.querySelectorAll('.animate-pulse');
     expect(skeletonLines.length).toBeGreaterThan(0);
   });
 
-  it('shows elapsed timer when startTime is provided', () => {
-    render(<LoadingState startTime={Date.now() - 2500} />);
+  it('shows elapsed timer when pipelineStart is provided', () => {
+    render(<LoadingState phases={activePhases} pipelineStart={now - 2500} />);
     const timer = screen.getByTestId('elapsed-timer');
     expect(timer).toBeInTheDocument();
-    // Should show roughly 2.5s (may vary slightly)
     expect(timer.textContent).toMatch(/\d+\.\ds/);
   });
 
-  it('does not show timer when no startTime', () => {
-    render(<LoadingState />);
-    expect(screen.queryByTestId('elapsed-timer')).not.toBeInTheDocument();
+  it('marks active phase with data-phase-state="active"', () => {
+    render(<LoadingState phases={activePhases} pipelineStart={now - 3000} />);
+    const phase0 = screen.getByTestId('phase-0');
+    expect(phase0.getAttribute('data-phase-state')).toBe('active');
+  });
+
+  it('marks waiting phase with data-phase-state="waiting"', () => {
+    render(<LoadingState phases={activePhases} pipelineStart={now - 3000} />);
+    const phase1 = screen.getByTestId('phase-1');
+    expect(phase1.getAttribute('data-phase-state')).toBe('waiting');
+  });
+
+  it('marks completed phase with data-phase-state="completed"', () => {
+    render(<LoadingState phases={completedStoryPhases} pipelineStart={now - 6000} />);
+    const phase0 = screen.getByTestId('phase-0');
+    expect(phase0.getAttribute('data-phase-state')).toBe('completed');
+  });
+
+  it('shows header text', () => {
+    render(<LoadingState phases={activePhases} pipelineStart={now} />);
+    expect(screen.getByText('Preparing your moment in history')).toBeInTheDocument();
+  });
+
+  it('renders checkmark for completed phases', () => {
+    render(<LoadingState phases={allCompletedPhases} pipelineStart={now - 6000} />);
+    const phase0 = screen.getByTestId('phase-0');
+    expect(phase0.textContent).toContain('✓');
   });
 });

--- a/src/__tests__/costs.test.ts
+++ b/src/__tests__/costs.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CLAUDE_INPUT_COST_PER_TOKEN,
+  CLAUDE_OUTPUT_COST_PER_TOKEN,
+  ELEVENLABS_COST_PER_CHAR,
+  calculateCost,
+  formatCost,
+} from '@/lib/costs';
+
+describe('Cost constants', () => {
+  it('Claude input cost is positive', () => {
+    expect(CLAUDE_INPUT_COST_PER_TOKEN).toBeGreaterThan(0);
+  });
+
+  it('Claude output cost is positive and higher than input', () => {
+    expect(CLAUDE_OUTPUT_COST_PER_TOKEN).toBeGreaterThan(0);
+    expect(CLAUDE_OUTPUT_COST_PER_TOKEN).toBeGreaterThan(CLAUDE_INPUT_COST_PER_TOKEN);
+  });
+
+  it('ElevenLabs cost per char is positive', () => {
+    expect(ELEVENLABS_COST_PER_CHAR).toBeGreaterThan(0);
+  });
+
+  it('Claude input matches $1.00/1M tokens', () => {
+    expect(CLAUDE_INPUT_COST_PER_TOKEN).toBeCloseTo(1.0 / 1_000_000, 10);
+  });
+
+  it('Claude output matches $5.00/1M tokens', () => {
+    expect(CLAUDE_OUTPUT_COST_PER_TOKEN).toBeCloseTo(5.0 / 1_000_000, 10);
+  });
+});
+
+describe('calculateCost', () => {
+  it('calculates typical story cost (~$0.09-0.15)', () => {
+    const cost = calculateCost({
+      inputTokens: 700,
+      outputTokens: 300,
+      ttsCharacters: 1100,
+    });
+    // Claude: 700 * $0.000001 + 300 * $0.000005 = $0.0007 + $0.0015 = $0.0022
+    // TTS:    1100 * $0.00011 = $0.121
+    // Total:  ~$0.1232
+    expect(cost).toBeGreaterThan(0.09);
+    expect(cost).toBeLessThan(0.20);
+  });
+
+  it('returns 0 for zero usage', () => {
+    const cost = calculateCost({ inputTokens: 0, outputTokens: 0, ttsCharacters: 0 });
+    expect(cost).toBe(0);
+  });
+
+  it('TTS dominates total cost (>90%)', () => {
+    const data = { inputTokens: 700, outputTokens: 300, ttsCharacters: 1100 };
+    const total = calculateCost(data);
+    const claudeOnly = calculateCost({ ...data, ttsCharacters: 0 });
+    expect(claudeOnly / total).toBeLessThan(0.10); // Claude is <10% of total
+  });
+});
+
+describe('formatCost', () => {
+  it('formats normal cost as ~$X.XX', () => {
+    expect(formatCost(0.12)).toBe('~$0.12');
+  });
+
+  it('formats sub-penny cost as <$0.01', () => {
+    expect(formatCost(0.005)).toBe('<$0.01');
+  });
+
+  it('formats zero as <$0.01', () => {
+    expect(formatCost(0)).toBe('<$0.01');
+  });
+
+  it('rounds to 2 decimal places', () => {
+    expect(formatCost(0.1234)).toBe('~$0.12');
+    expect(formatCost(0.1256)).toBe('~$0.13');
+  });
+});

--- a/src/__tests__/issueTwoRegression.test.ts
+++ b/src/__tests__/issueTwoRegression.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('Issue #2: Pipeline sends cost data in NDJSON', () => {
+  const pipelineSource = fs.readFileSync(
+    path.resolve(__dirname, '../app/api/pipeline/route.ts'), 'utf-8'
+  );
+
+  it('story event includes inputTokens', () => {
+    expect(pipelineSource).toContain('inputTokens: message.usage.input_tokens');
+  });
+
+  it('story event includes outputTokens', () => {
+    expect(pipelineSource).toContain('outputTokens: message.usage.output_tokens');
+  });
+
+  it('audio event includes ttsCharacters', () => {
+    expect(pipelineSource).toContain('ttsCharacters: fullText.length');
+  });
+});
+
+describe('Issue #2: Cost module exports', () => {
+  const costsSource = fs.readFileSync(
+    path.resolve(__dirname, '../lib/costs.ts'), 'utf-8'
+  );
+
+  it('exports calculateCost function', () => {
+    expect(costsSource).toContain('export function calculateCost');
+  });
+
+  it('exports formatCost function', () => {
+    expect(costsSource).toContain('export function formatCost');
+  });
+
+  it('exports CostData interface', () => {
+    expect(costsSource).toContain('export interface CostData');
+  });
+});
+
+describe('Issue #2: Loading messages module exports', () => {
+  const messagesSource = fs.readFileSync(
+    path.resolve(__dirname, '../lib/loadingMessages.ts'), 'utf-8'
+  );
+
+  it('exports STORY_PHASE_MESSAGES', () => {
+    expect(messagesSource).toContain('export const STORY_PHASE_MESSAGES');
+  });
+
+  it('exports AUDIO_PHASE_MESSAGES', () => {
+    expect(messagesSource).toContain('export const AUDIO_PHASE_MESSAGES');
+  });
+
+  it('exports pickRandom function', () => {
+    expect(messagesSource).toContain('export function pickRandom');
+  });
+});
+
+describe('Issue #2: LoadingState uses multi-phase interface', () => {
+  const loadingSource = fs.readFileSync(
+    path.resolve(__dirname, '../components/LoadingState.tsx'), 'utf-8'
+  );
+
+  it('exports LoadingPhase interface', () => {
+    expect(loadingSource).toContain('export interface LoadingPhase');
+  });
+
+  it('accepts phases prop', () => {
+    expect(loadingSource).toContain('phases: LoadingPhase[]');
+  });
+
+  it('accepts pipelineStart prop', () => {
+    expect(loadingSource).toContain('pipelineStart: number | null');
+  });
+});
+
+describe('Issue #2: page.tsx uses new loading and cost features', () => {
+  const pageSource = fs.readFileSync(
+    path.resolve(__dirname, '../app/page.tsx'), 'utf-8'
+  );
+
+  it('imports pickRandom and message arrays', () => {
+    expect(pageSource).toMatch(/import.*pickRandom.*from.*loadingMessages/);
+  });
+
+  it('imports calculateCost and formatCost', () => {
+    expect(pageSource).toMatch(/import.*calculateCost.*from.*costs/);
+    expect(pageSource).toMatch(/import.*formatCost.*from.*costs/);
+  });
+
+  it('timing label includes cost estimate', () => {
+    expect(pageSource).toContain('Est. cost:');
+  });
+
+  it('renamed Audio to Narration in timing label', () => {
+    expect(pageSource).toContain('Narration');
+    // Should NOT use "Audio" in the timing label anymore
+    expect(pageSource).not.toMatch(/`Story.*· Audio \$/);
+  });
+});

--- a/src/__tests__/loadingMessages.test.ts
+++ b/src/__tests__/loadingMessages.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+  STORY_PHASE_MESSAGES,
+  AUDIO_PHASE_MESSAGES,
+  pickRandom,
+} from '@/lib/loadingMessages';
+
+describe('STORY_PHASE_MESSAGES', () => {
+  it('has at least 3 messages', () => {
+    expect(STORY_PHASE_MESSAGES.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('all messages end with "..."', () => {
+    for (const msg of STORY_PHASE_MESSAGES) {
+      expect(msg).toMatch(/\.\.\.$/);
+    }
+  });
+
+  it('all messages are non-empty strings', () => {
+    for (const msg of STORY_PHASE_MESSAGES) {
+      expect(typeof msg).toBe('string');
+      expect(msg.length).toBeGreaterThan(10);
+    }
+  });
+});
+
+describe('AUDIO_PHASE_MESSAGES', () => {
+  it('has at least 3 messages', () => {
+    expect(AUDIO_PHASE_MESSAGES.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('all messages end with "..."', () => {
+    for (const msg of AUDIO_PHASE_MESSAGES) {
+      expect(msg).toMatch(/\.\.\.$/);
+    }
+  });
+
+  it('all messages are non-empty strings', () => {
+    for (const msg of AUDIO_PHASE_MESSAGES) {
+      expect(typeof msg).toBe('string');
+      expect(msg.length).toBeGreaterThan(10);
+    }
+  });
+});
+
+describe('pickRandom', () => {
+  it('returns an element from the array', () => {
+    const items = ['a', 'b', 'c'];
+    const result = pickRandom(items);
+    expect(items).toContain(result);
+  });
+
+  it('works with single-element arrays', () => {
+    expect(pickRandom(['only'])).toBe('only');
+  });
+
+  it('returns a story phase message', () => {
+    const msg = pickRandom(STORY_PHASE_MESSAGES);
+    expect(STORY_PHASE_MESSAGES).toContain(msg);
+  });
+
+  it('returns an audio phase message', () => {
+    const msg = pickRandom(AUDIO_PHASE_MESSAGES);
+    expect(AUDIO_PHASE_MESSAGES).toContain(msg);
+  });
+});

--- a/src/app/api/pipeline/route.ts
+++ b/src/app/api/pipeline/route.ts
@@ -85,6 +85,9 @@ export async function POST(request: NextRequest) {
           mlaCitation: input.mlaCitation || null,
           date: { month, day },
           genre: genre || null,
+          // Token usage for cost estimation (Issue #2)
+          inputTokens: message.usage.input_tokens,
+          outputTokens: message.usage.output_tokens,
         }) + '\n'));
 
         // ── Phase 2: Generate TTS with ElevenLabs Flash ────────────
@@ -132,6 +135,8 @@ export async function POST(request: NextRequest) {
         controller.enqueue(encoder.encode(JSON.stringify({
           type: 'audio',
           audio: base64Audio,
+          // Character count for cost estimation (Issue #2)
+          ttsCharacters: fullText.length,
         }) + '\n'));
 
       } catch (err: unknown) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,11 +4,13 @@ import { useState, useRef } from 'react';
 import { format } from 'date-fns';
 import CalendarPicker from '@/components/CalendarPicker';
 import StoryCard from '@/components/StoryCard';
-import LoadingState from '@/components/LoadingState';
+import LoadingState, { type LoadingPhase } from '@/components/LoadingState';
 import useHistoryStory from '@/hooks/useHistoryStory';
 import { useTextToSpeech } from '@/hooks/useTextToSpeech';
 import { useBackgroundMusic } from '@/hooks/useBackgroundMusic';
 import { getRandomGenre } from '@/lib/genres';
+import { pickRandom, STORY_PHASE_MESSAGES, AUDIO_PHASE_MESSAGES } from '@/lib/loadingMessages';
+import { calculateCost, formatCost, type CostData } from '@/lib/costs';
 
 interface PipelineTiming {
   storyMs: number | null;
@@ -21,6 +23,8 @@ export default function Home() {
   const [selectedDate, setSelectedDate] = useState<Date | undefined>();
   const [pipelineStart, setPipelineStart] = useState<number | null>(null);
   const [timing, setTiming] = useState<PipelineTiming>({ storyMs: null, audioMs: null });
+  const [phases, setPhases] = useState<LoadingPhase[]>([]);
+  const [costData, setCostData] = useState<CostData | null>(null);
   const phaseStartRef = useRef<number>(0);
 
   const history = useHistoryStory();
@@ -39,10 +43,19 @@ export default function Home() {
     tts.cleanup();
     bgMusic.stop();
     setTiming({ storyMs: null, audioMs: null });
+    setCostData(null);
 
     const now = Date.now();
     setPipelineStart(now);
     phaseStartRef.current = now;
+
+    // Pick random themed messages for this run
+    const storyMsg = pickRandom(STORY_PHASE_MESSAGES);
+    const audioMsg = pickRandom(AUDIO_PHASE_MESSAGES);
+    setPhases([
+      { label: storyMsg, startTime: now },
+      { label: audioMsg, startTime: 0 },
+    ]);
 
     // Warm up audio element during user click to satisfy autoplay policy
     tts.warmUp();
@@ -80,9 +93,21 @@ export default function Home() {
           const event = JSON.parse(line);
 
           if (event.type === 'story') {
-            const storyMs = Date.now() - phaseStartRef.current;
+            const storyEnd = Date.now();
+            const storyMs = storyEnd - phaseStartRef.current;
             setTiming(prev => ({ ...prev, storyMs }));
-            phaseStartRef.current = Date.now();
+            phaseStartRef.current = storyEnd;
+
+            // Close phase 1, open phase 2
+            setPhases(prev => [
+              { ...prev[0], endTime: storyEnd },
+              { ...prev[1], startTime: storyEnd },
+            ]);
+
+            // Capture token usage for cost estimation
+            if (event.inputTokens !== undefined && event.outputTokens !== undefined) {
+              setCostData({ inputTokens: event.inputTokens, outputTokens: event.outputTokens, ttsCharacters: 0 });
+            }
 
             // Display story immediately — TTS is already generating on the server
             history.setResult({
@@ -95,13 +120,25 @@ export default function Home() {
               genre: event.genre,
             });
 
-            // Show "Finding our history professor..." while audio generates
+            // Show audio phase message while audio generates
             tts.setLoadingState(true);
           }
 
           if (event.type === 'audio') {
-            const audioMs = Date.now() - phaseStartRef.current;
+            const audioEnd = Date.now();
+            const audioMs = audioEnd - phaseStartRef.current;
             setTiming(prev => ({ ...prev, audioMs }));
+
+            // Close phase 2
+            setPhases(prev => [
+              prev[0],
+              { ...prev[1], endTime: audioEnd },
+            ]);
+
+            // Capture TTS character count for cost estimation
+            if (event.ttsCharacters !== undefined) {
+              setCostData(prev => prev ? { ...prev, ttsCharacters: event.ttsCharacters } : prev);
+            }
 
             // Decode base64 → blob → play
             const binaryString = atob(event.audio);
@@ -177,8 +214,9 @@ export default function Home() {
         />
 
         {/* Story Area */}
-        {history.loading && <LoadingState message="Uncovering history..." startTime={pipelineStart} />}
-        {tts.loading && !history.loading && <LoadingState message="Finding our history professor..." startTime={pipelineStart} />}
+        {(history.loading || tts.loading) && phases.length > 0 && (
+          <LoadingState phases={phases} pipelineStart={pipelineStart} />
+        )}
 
         {history.error && (
           <div className="bg-red-900/30 border border-red-800 rounded-xl p-4 max-w-2xl mx-auto text-center">
@@ -215,7 +253,11 @@ export default function Home() {
             onToggleMusic={bgMusic.toggleMute}
             timingLabel={
               timing.storyMs !== null && timing.audioMs !== null
-                ? `Story ${formatMs(timing.storyMs)} · Audio ${formatMs(timing.audioMs)} · Total ${formatMs(timing.storyMs + timing.audioMs)}`
+                ? `Story ${formatMs(timing.storyMs)} · Narration ${formatMs(timing.audioMs)} · Total ${formatMs(timing.storyMs + timing.audioMs)}${
+                    costData && costData.ttsCharacters > 0
+                      ? ` · Est. cost: ${formatCost(calculateCost(costData))}`
+                      : ''
+                  }`
                 : timing.storyMs !== null
                   ? `Story ${formatMs(timing.storyMs)}`
                   : undefined

--- a/src/components/LoadingState.tsx
+++ b/src/components/LoadingState.tsx
@@ -2,36 +2,66 @@
 
 import { useState, useEffect, useRef } from 'react';
 
-interface LoadingStateProps {
-  message?: string;
-  startTime?: number | null;
+export interface LoadingPhase {
+  /** Display message for this phase (e.g. "Searching the archives...") */
+  label: string;
+  /** Timestamp (ms) when the phase started — 0 means not started yet */
+  startTime: number;
+  /** Timestamp (ms) when the phase ended — undefined means still active or waiting */
+  endTime?: number;
 }
 
-export default function LoadingState({ message = 'Uncovering history...', startTime }: LoadingStateProps) {
-  const [elapsed, setElapsed] = useState(0);
+interface LoadingStateProps {
+  phases: LoadingPhase[];
+  pipelineStart: number | null;
+}
+
+/**
+ * Multi-phase loading indicator with live-updating per-phase timers.
+ *
+ * Phase states:
+ *   - Completed (endTime set): dimmed text, fixed duration
+ *   - Active (startTime > 0, no endTime): amber text, live timer
+ *   - Waiting (startTime === 0): muted text, ellipsis
+ */
+export default function LoadingState({ phases, pipelineStart }: LoadingStateProps) {
+  const [tick, setTick] = useState(0);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
+  // Tick every 250ms to update live timers
   useEffect(() => {
-    if (!startTime) {
-      setElapsed(0);
-      return;
-    }
+    if (!pipelineStart) return;
 
-    const tick = () => {
-      setElapsed(Math.floor((Date.now() - startTime) / 100) / 10);
-    };
-    tick();
-    intervalRef.current = setInterval(tick, 250); // 4 updates/sec — smooth enough for .toFixed(1) display
-
+    intervalRef.current = setInterval(() => setTick(t => t + 1), 250);
     return () => {
       if (intervalRef.current) clearInterval(intervalRef.current);
     };
-  }, [startTime]);
+  }, [pipelineStart]);
+
+  // Suppress unused-var lint for the tick counter (drives re-renders)
+  void tick;
+
+  /** Format milliseconds as "3.2s" */
+  const formatMs = (ms: number) => `${(ms / 1000).toFixed(1)}s`;
+
+  /** Calculate elapsed for a phase */
+  const phaseElapsed = (phase: LoadingPhase): string => {
+    if (phase.endTime) return formatMs(phase.endTime - phase.startTime);
+    if (phase.startTime > 0) return formatMs(Date.now() - phase.startTime);
+    return '';
+  };
+
+  /** Determine phase visual state */
+  const phaseState = (phase: LoadingPhase): 'completed' | 'active' | 'waiting' => {
+    if (phase.endTime) return 'completed';
+    if (phase.startTime > 0) return 'active';
+    return 'waiting';
+  };
 
   return (
     <div className="bg-stone-900 border border-stone-700 rounded-xl p-6 shadow-lg max-w-2xl mx-auto">
-      {/* Quill icon + message + timer */}
-      <div className="flex items-center gap-3 mb-6">
+      {/* Quill icon */}
+      <div className="flex items-center gap-3 mb-5">
         <svg
           className="w-6 h-6 text-amber-400 animate-bounce"
           viewBox="0 0 24 24"
@@ -44,14 +74,68 @@ export default function LoadingState({ message = 'Uncovering history...', startT
           <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
           <path d="m15 5 4 4" />
         </svg>
-        <span className="text-amber-400 font-medium animate-pulse">
-          {message}
+        <span className="text-amber-400 font-medium">
+          Preparing your moment in history
         </span>
-        {startTime && (
+        {pipelineStart && (
           <span className="text-stone-500 text-sm font-mono ml-auto" data-testid="elapsed-timer">
-            {elapsed.toFixed(1)}s
+            {formatMs(Date.now() - pipelineStart)}
           </span>
         )}
+      </div>
+
+      {/* Phase progress rows */}
+      <div className="space-y-3 mb-6" data-testid="phase-list">
+        {phases.map((phase, i) => {
+          const state = phaseState(phase);
+          return (
+            <div
+              key={i}
+              className="flex items-center gap-3"
+              data-testid={`phase-${i}`}
+              data-phase-state={state}
+            >
+              {/* Phase indicator */}
+              {state === 'completed' && (
+                <span className="w-5 h-5 flex items-center justify-center text-green-500 text-sm" aria-label="completed">✓</span>
+              )}
+              {state === 'active' && (
+                <span className="w-5 h-5 flex items-center justify-center">
+                  <span className="w-2.5 h-2.5 bg-amber-400 rounded-full animate-pulse" />
+                </span>
+              )}
+              {state === 'waiting' && (
+                <span className="w-5 h-5 flex items-center justify-center">
+                  <span className="w-2.5 h-2.5 bg-stone-600 rounded-full" />
+                </span>
+              )}
+
+              {/* Phase label */}
+              <span
+                className={
+                  state === 'active'
+                    ? 'text-amber-400 font-medium text-sm'
+                    : state === 'completed'
+                      ? 'text-stone-500 text-sm'
+                      : 'text-stone-600 text-sm'
+                }
+              >
+                {phase.label}
+              </span>
+
+              {/* Phase timer */}
+              <span
+                className={`text-sm font-mono ml-auto ${
+                  state === 'active' ? 'text-amber-400' : 'text-stone-600'
+                }`}
+              >
+                {state === 'active' && phaseElapsed(phase)}
+                {state === 'completed' && phaseElapsed(phase)}
+                {state === 'waiting' && '—'}
+              </span>
+            </div>
+          );
+        })}
       </div>
 
       {/* Skeleton lines */}

--- a/src/lib/costs.ts
+++ b/src/lib/costs.ts
@@ -1,0 +1,37 @@
+/**
+ * Cost estimation for story generation pipeline.
+ *
+ * Pricing sources (see README.md lines 209-273):
+ *   Claude Haiku 4.5 — https://docs.anthropic.com/en/docs/about-claude/models
+ *   ElevenLabs Flash v2.5 — https://elevenlabs.io/pricing
+ *
+ * These constants should be updated if provider pricing changes.
+ */
+
+// Claude Haiku 4.5 pricing (per token)
+export const CLAUDE_INPUT_COST_PER_TOKEN = 1.0 / 1_000_000; // $1.00 / 1M tokens
+export const CLAUDE_OUTPUT_COST_PER_TOKEN = 5.0 / 1_000_000; // $5.00 / 1M tokens
+
+// ElevenLabs Flash v2.5 pricing (per character, Creator plan ~$0.11/1K chars)
+export const ELEVENLABS_COST_PER_CHAR = 0.00011;
+
+export interface CostData {
+  inputTokens: number;
+  outputTokens: number;
+  ttsCharacters: number;
+}
+
+/** Calculate total estimated cost in USD for a single story generation. */
+export function calculateCost(data: CostData): number {
+  const claudeCost =
+    data.inputTokens * CLAUDE_INPUT_COST_PER_TOKEN +
+    data.outputTokens * CLAUDE_OUTPUT_COST_PER_TOKEN;
+  const ttsCost = data.ttsCharacters * ELEVENLABS_COST_PER_CHAR;
+  return claudeCost + ttsCost;
+}
+
+/** Format a dollar amount for display (e.g. "~$0.12" or "<$0.01"). */
+export function formatCost(dollars: number): string {
+  if (dollars < 0.01) return '<$0.01';
+  return `~$${dollars.toFixed(2)}`;
+}

--- a/src/lib/loadingMessages.ts
+++ b/src/lib/loadingMessages.ts
@@ -1,0 +1,31 @@
+/**
+ * Themed loading messages for each pipeline phase.
+ *
+ * Phase 1 (story generation): archive / discovery theme
+ * Phase 2 (audio narration): Voyagers!-inspired time-travel adventure theme
+ *
+ * Future: each message will be paired with a pre-generated Midjourney image
+ * stored in public/loading/ (Phase 2 of Issue #2).
+ */
+
+export const STORY_PHASE_MESSAGES = [
+  'Searching the archives...',
+  'Consulting the scrolls...',
+  'Dusting off the records...',
+  'Decoding an ancient manuscript...',
+  'Opening the vault of forgotten stories...',
+];
+
+export const AUDIO_PHASE_MESSAGES = [
+  'The Omni is locked on — engaging time coordinates...',
+  'Firing up the time machine...',
+  'The pilot is charting a course through history...',
+  'Calibrating the temporal compass...',
+  'Spinning up the portal — adventure awaits...',
+  'The green light is flashing — history needs us...',
+];
+
+/** Pick a random element from a non-empty array. */
+export function pickRandom<T>(items: T[]): T {
+  return items[Math.floor(Math.random() * items.length)];
+}


### PR DESCRIPTION
## Summary
- Add themed loading messages: archive/discovery (Phase 1) + Voyagers!/time-travel (Phase 2)
- Multi-phase progress UI with live per-phase timers and phase state indicators (✓, pulsing dot, waiting)
- Display estimated cost in story footer: `Story 2.1s · Narration 4.3s · Total 6.4s · Est. cost: ~$0.12`
- Pipeline NDJSON now includes `inputTokens`, `outputTokens`, and `ttsCharacters` for client-side cost calculation
- Renamed "Audio" to "Narration" in timing label

## New Files
- `src/lib/loadingMessages.ts` — 5 story + 6 audio themed messages with `pickRandom` helper
- `src/lib/costs.ts` — Cost constants, `calculateCost()`, `formatCost()` matching README rates

## Modified Files
- `src/app/api/pipeline/route.ts` — Token counts + char count in NDJSON events
- `src/components/LoadingState.tsx` — Multi-phase progress UI (replaces single-message design)
- `src/app/page.tsx` — Phase state, cost data, message rotation

## Test Coverage
- 146/146 tests passing (104 existing + 42 new)
- New: `costs.test.ts`, `loadingMessages.test.ts`, `LoadingState.test.tsx` (updated), `issueTwoRegression.test.ts`

## Future Enhancement
Phase 2: Each loading message will be paired with a pre-generated Midjourney image (retro sci-fi/Voyagers! aesthetic). Not in scope for this PR.

## Test plan
- [ ] `pnpm install && pnpm test` (146 tests pass)
- [ ] `pnpm build` (clean, no errors)
- [ ] Run app locally and verify themed loading messages rotate randomly
- [ ] Verify phase progress shows active/completed/waiting states
- [ ] Verify cost estimate appears in story footer after generation

Resolves #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)