### PR TITLE
release: promote docs suite update to prod

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,457 @@
+# Architecture — Complete Technology Reference
+
+**This Moment in History** — System Design & Technology Map
+By Kenneth Benavides | MVP 10 | March 2026
+
+---
+
+## System Overview
+
+This Moment in History is a full-stack AI storytelling application built on Next.js 16. A single streaming API endpoint coordinates two external services — Anthropic Claude for story generation and ElevenLabs for voice narration — and delivers both results to the browser over an NDJSON stream. The client renders stories immediately while audio is still generating on the server. Background music, cost estimation, and system-controlled UI choreography run entirely on the client with zero additional API calls.
+
+---
+
+## Technology Stack
+
+Every dependency was chosen for a specific reason. This table covers the full stack.
+
+### Runtime Dependencies
+
+| Technology | Version | Purpose | Why This One |
+|-----------|---------|---------|-------------|
+| **Next.js** | 16.1.6 | Full-stack framework (App Router) | Server-side API routes protect API keys. File-based routing, streaming responses, and React Server Components in one deployable unit. No separate backend needed. |
+| **React** | 19.2.3 | UI framework | Hooks-first architecture. `useRef` for timing accuracy in async code, `useCallback` for stable handler identity, `useEffect` for audio lifecycle. React 19's rendering pipeline handles frequent state updates during streaming without jank. |
+| **react-dom** | 19.2.3 | React DOM renderer | Required by React for browser rendering. |
+| **@anthropic-ai/sdk** | ^0.78.0 | Claude API client | Official TypeScript SDK with full type safety for `tool_use`, `tool_choice`, and structured message responses. |
+| **react-day-picker** | ^9.14.0 | Calendar date picker | Lightweight, accessible, fully customizable. Dark theme applied via CSS class overrides. Future dates disabled with a single prop. |
+| **date-fns** | ^4.1.0 | Date formatting | Tree-shakeable — only `format` is imported. No moment.js-sized bundle penalty. |
+
+### Dev Dependencies
+
+| Technology | Version | Purpose | Why This One |
+|-----------|---------|---------|-------------|
+| **TypeScript** | ^5 | Type safety | Type-safe API contracts between server and client. Catches `tool_use` response shape errors at compile time. |
+| **Tailwind CSS** | ^4 | Utility-first styling | Zero context-switching between component and CSS files. The entire amber/stone dark theme is expressed in class names. |
+| **@tailwindcss/postcss** | ^4 | PostCSS integration | Tailwind 4's build pipeline via PostCSS. |
+| **Vitest** | ^4.1.0 | Test runner | Native TypeScript support, 2.5-second execution for 214 tests. `jsdom` environment for component tests without a real browser. |
+| **@testing-library/react** | ^16.3.2 | Component testing | Tests user-visible behavior (text, clicks), not implementation details (state, CSS classes). |
+| **@testing-library/jest-dom** | ^6.9.1 | DOM assertions | `toBeInTheDocument()`, `toHaveAttribute()`, and other DOM-specific matchers. |
+| **@vitejs/plugin-react** | ^6.0.1 | React HMR for Vitest | Enables JSX transform and fast refresh in the test environment. |
+| **jsdom** | ^28.1.0 | Browser simulation | Provides `window`, `document`, `Audio`, and DOM APIs for component tests. |
+| **ESLint** | ^9 | Code linting | Catches common errors and enforces code style. |
+| **eslint-config-next** | 16.1.6 | Next.js linting rules | Framework-specific rules for App Router, server components, and image optimization. |
+
+### External Services (Not in package.json)
+
+| Service | Model / Config | Purpose | Why This One |
+|---------|---------------|---------|-------------|
+| **Anthropic Claude API** | `claude-haiku-4-5-20251001` | Story generation | Follows complex multi-constraint prompts with high fidelity. `tool_use` forces structured JSON output in a single call. Haiku 4.5 delivers similar quality to Sonnet for 150-word vignettes at 1/3 the cost and 3-5x the speed. |
+| **ElevenLabs TTS API** | `eleven_flash_v2_5`, Adam voice (`pNInz6obpgDQGcFmaJgB`) | Voice narration | Neural voice synthesis. Flash v2.5 generates audio in 5-8 seconds vs. 18+ seconds with multilingual model. Adam's deep, authoritative tone matches the literary journalism style. |
+| **Vercel** | — | Hosting & deployment | Zero-config Next.js hosting. Automatic HTTPS, edge network, preview deployments. |
+
+### Static Assets
+
+| Asset | File | Purpose |
+|-------|------|---------|
+| **Background Music** | `public/audio/chronostream-runner.mp3` | Voyagers!-themed ambient soundtrack. Generated once via ElevenLabs Sound Effects, served as a static file — zero per-request cost. Loops at 12% volume with 2s fade-in and 3s fade-out. |
+
+---
+
+## Data Flow
+
+The complete request lifecycle from user click to audio playback:
+
+```
+User clicks a date (or "Random History")
+    |
+    v
+page.tsx: runPipeline(date, genre?)
+    |
+    |-- tts.cleanup()            // Destroy previous audio element + blob
+    |-- bgMusic.stop()           // Hard stop previous music
+    |-- tts.warmUp()             // Create Audio element (satisfies autoplay policy)
+    |-- bgMusic.warmUp()         // Create bg Audio element (satisfies autoplay policy)
+    |-- history.startLoading()   // Set loading state
+    |-- setPhases([story, audio]) // Pick random themed loading messages
+    |
+    v
+fetch('/api/pipeline', { month, day, genre? })
+    |
+    v
+pipeline/route.ts (SERVER):
+    |
+    |-- rateLimit(ip)            // 10 req/IP/60s — reject with 429 if exceeded
+    |-- validateRequest(body)    // month 1-12, day 1-31, genre in GENRES list
+    |
+    |-- Phase 1: Claude Haiku 4.5           [~3-4 seconds]
+    |   |-- System prompt (400+ words) + tool_choice: publish_vignette
+    |   |-- Returns: story, eventTitle, eventYear, mlaCitation
+    |   |-- FLUSH: {"type":"story", ..., inputTokens, outputTokens}\n
+    |
+    |-- Phase 2: ElevenLabs Flash v2.5      [~5-8 seconds]
+    |   |-- story + outro text --> POST to ElevenLabs API
+    |   |-- Returns: audio bytes (MP3)
+    |   |-- FLUSH: {"type":"audio", "audio":"<base64>", ttsCharacters}\n
+    |
+    v
+page.tsx (CLIENT reads NDJSON stream):
+    |
+    |-- "story" event:
+    |   |-- history.setResult()         // Display story text immediately
+    |   |-- tts.setLoadingState(true)   // Show themed audio phase message
+    |   |-- setCostData(tokens)         // Begin cost estimation
+    |   |-- Update phase timers         // Show story generation time
+    |
+    |-- "audio" event:
+    |   |-- Decode base64 --> Blob
+    |   |-- tts.playBlob(blob)          // Auto-play narration
+    |   |-- bgMusic.play()              // Fade in Voyagers! music (2s)
+    |   |-- setCostData(chars)          // Complete cost estimation
+    |   |-- Update phase timers         // Show audio generation time
+    |
+    v
+User hears narration with background music.
+    |-- LoadingState collapses (system-controlled)
+    |-- StoryCard expands (system-controlled)
+    |-- When narration ends: bgMusic.fadeOut() (3s fade)
+    |-- Controls: Play/Pause, Replay, Download MP3, Mute Music, Random History
+```
+
+---
+
+## API Endpoints
+
+### POST `/api/pipeline` — Primary Streaming Endpoint
+
+The main endpoint used in production. Handles story generation and TTS in a single streaming response.
+
+**Request:**
+
+```json
+{
+  "month": 3,
+  "day": 14,
+  "genre": "True Crime"
+}
+```
+
+| Field | Type | Required | Validation |
+|-------|------|----------|-----------|
+| `month` | integer | Yes | 1-12 |
+| `day` | integer | Yes | 1-31 |
+| `genre` | string | No | Must match one of 20 curated genres exactly |
+
+**Response:** `Content-Type: application/x-ndjson`
+
+```
+Line 1: {"type":"story","story":"...","eventTitle":"...","eventYear":"1945","mlaCitation":"...","date":{"month":3,"day":14},"genre":"True Crime","inputTokens":700,"outputTokens":295}
+Line 2: {"type":"audio","audio":"SUQzBAAAAAAAI1RTU0UAAA...","ttsCharacters":1150}
+```
+
+**Error responses:**
+
+| Status | Body | Cause |
+|--------|------|-------|
+| 400 | `{"error": "Invalid month"}` | Validation failure |
+| 429 | `{"error": "Too many requests", "retryAfter": 45}` | Rate limit exceeded |
+| 500 | `{"error": "API key not configured"}` | Missing env var |
+
+### POST `/api/history` — Standalone Story Endpoint (Fallback)
+
+Generates a story without TTS. Returns a standard JSON response (not streaming).
+
+**Request:** Same as pipeline. **Response:** JSON with `story`, `eventTitle`, `eventYear`, `mlaCitation`, `genre`.
+
+### POST `/api/tts` — Standalone TTS Endpoint (Fallback)
+
+Converts text to speech. Returns raw audio bytes (`audio/mpeg`).
+
+**Request:**
+
+```json
+{
+  "text": "The air smells of...",
+  "eventTitle": "The Fall of Berlin",
+  "eventDate": "November 9",
+  "eventYear": "1989"
+}
+```
+
+| Field | Type | Required | Validation |
+|-------|------|----------|-----------|
+| `text` | string | Yes | Non-empty, max 5,000 characters |
+| `eventTitle` | string | No | Appended to branding outro |
+| `eventDate` | string | No | Appended to branding outro |
+| `eventYear` | string | No | Appended to branding outro |
+
+---
+
+## Component Tree
+
+```
+<Home>  (page.tsx — client component, pipeline orchestrator)
+  |
+  |-- <CalendarPicker>                  Props: selectedDate, onDateSelect
+  |     Uses: react-day-picker, date-fns
+  |
+  |-- <LoadingState>                    Props: phases[], pipelineStart, autoExpand, autoCollapse
+  |     |-- <Collapsible locked>        System-controlled expand/collapse
+  |     |     Header: phase label + live elapsed timer
+  |     |     Body: phase list with timing + skeleton lines
+  |     Persists in DOM once pipeline starts (never unmounted)
+  |
+  |-- <StoryCard>                       Props: story, date, eventTitle, eventYear, mlaCitation,
+  |     |-- <Collapsible locked>              genre, audio controls, timing, autoExpand
+  |     |     Header: date + event title + loading indicator
+  |     |     Body: genre badge, event header, story text, MLA citation,
+  |     |           audio controls (play/pause, replay, download),
+  |     |           music toggle, timing label + cost estimate
+  |     Persists in DOM once story arrives (never unmounted)
+  |
+  |-- Error display                     Conditional: only when history.error is set
+  |
+  |-- Empty state                       Conditional: no date selected, not loading
+```
+
+### Collapsible Component (Reusable)
+
+The `<Collapsible>` component powers both LoadingState and StoryCard with two modes:
+
+| Mode | Header | Expand/Collapse | Use Case |
+|------|--------|----------------|----------|
+| **Interactive** (default) | Clickable `<button>` with aria-expanded | User toggles via click | General-purpose accordion |
+| **Locked** | Non-interactive `<div>` | System-controlled via `expanded` prop | LoadingState, StoryCard |
+
+Animation uses measured `scrollHeight` for natural height transitions that work with dynamic content (live timers, varying story length).
+
+---
+
+## Hook Architecture
+
+State is separated into three independent hooks. Each manages one concern and exposes a clean API to `page.tsx`.
+
+### useHistoryStory — Story State
+
+| Method | Purpose |
+|--------|---------|
+| `fetchStory(date, genre?)` | Standalone fetch to `/api/history` (fallback) |
+| `startLoading()` | Set loading state for streaming pipeline |
+| `setResult(data)` | Update story + metadata from pipeline stream |
+| `setErrorState(msg)` | Set error and clear story |
+
+**State:** `story`, `metadata` (eventTitle, eventYear, mlaCitation), `loading`, `error`, `activeGenre`
+
+### useTextToSpeech — Narration Playback
+
+| Method | Purpose |
+|--------|---------|
+| `warmUp()` | Create Audio element during user click (autoplay policy) |
+| `playBlob(blob, options?)` | Play pre-fetched audio, fire onStart/onEnd callbacks |
+| `speak(options)` | Fetch + play via `/api/tts` (fallback) |
+| `togglePlayPause()` | Toggle, returns new playing state (avoids stale closure) |
+| `replay()` | Reset to start, play, fire onStart |
+| `cleanup()` | Destroy audio element, revoke blob URL, reset state |
+| `download(filename?)` | Trigger browser download of current audio blob |
+| `setLoadingState(bool)` | External control of loading indicator |
+
+**State:** `loading`, `playing`, `paused`, `hasAudio`, `error`
+
+**Key pattern — `handleEndedRef`:** The `ended` event handler is stored in a `useRef` to maintain stable function identity. Without this, `addEventListener` and `removeEventListener` receive different function references on each render, causing ghost listeners.
+
+### useBackgroundMusic — Voyagers! Soundtrack
+
+| Method | Purpose |
+|--------|---------|
+| `warmUp()` | Create Audio element during user click (autoplay policy) |
+| `play()` | Start from beginning with 2s fade-in to 12% volume |
+| `fadeOut()` | 3s fade from current volume to 0, then pause + reset |
+| `stop()` | Immediate pause + reset (pipeline restart) |
+| `pause()` / `resume()` | Sync with narrator play/pause |
+| `toggleMute()` | Mute/unmute without starting or stopping playback |
+
+**State:** `muted`
+
+**Key pattern — asymmetric fade:** Fade-in is 2 seconds, fade-out is 3 seconds. This mirrors broadcast audio practice — listeners notice abrupt silence more than a slow swell.
+
+---
+
+## Key Design Patterns
+
+| Pattern | Where Used | Why It Matters |
+|---------|-----------|----------------|
+| **NDJSON Streaming** | `/api/pipeline` → `page.tsx` | Story displays immediately while audio still generates on server. Two events over standard `fetch()` — no SSE, no WebSockets, no polyfills. |
+| **warmUp()** | `useTextToSpeech`, `useBackgroundMusic` | Creates Audio elements synchronously during user click to satisfy browser autoplay policy. Without this, `audio.play()` is silently blocked when called from async callbacks. |
+| **tool_use + tool_choice** | Claude API call in pipeline | Forces structured JSON output (story, title, year, citation) in a single call. Eliminates regex parsing, retry logic, and malformed JSON errors. |
+| **useRef for handlers** | `handleEndedRef` in TTS hook | Stable function identity for `addEventListener`/`removeEventListener`. Prevents ghost event listeners across React re-renders. |
+| **useRef for timing** | `phaseStartRef` in `page.tsx` | `useRef` provides synchronous reads inside async callbacks. `useState` would give stale values due to React's batched updates. |
+| **Persistent DOM** | LoadingState, StoryCard | Cards mount once and stay in DOM. Expand/collapse controlled by props, not conditional rendering. Prevents Flash of Unmount when switching states. |
+| **Locked Collapsible** | LoadingState, StoryCard headers | System controls visibility — users cannot toggle. Headers render as `<div>` instead of `<button>`. Prevents premature interaction before audio is ready. |
+| **Asymmetric Fade** | Background music (2s in, 3s out) | Listeners notice silence more than swell. Longer fade-out creates a professional trail-off that mirrors broadcast audio production. |
+| **Constraint Prompting** | System prompt for Claude | 400+ words defining what to do, what NOT to do, and how to verify quality. Anti-patterns section prevents encyclopedic defaults. Produces consistent output even with smaller models. |
+| **Genre as Lens** | `buildUserMessage()` with genre | Genre shapes the story angle, not a database filter. Same date can yield 20 different stories. All historically accurate regardless of genre. |
+| **Derived State** | `const expanded = autoExpand` | No internal useState for expand/collapse. Component state is directly derived from props. Eliminates sync bugs between parent and child state. |
+| **Server-Side Overlap** | Pipeline route (story then TTS) | TTS fires immediately after Claude responds — zero client round-trip between phases. Saves 100-200ms plus architectural complexity. |
+
+---
+
+## Security Model
+
+### API Key Protection
+
+Both Anthropic and ElevenLabs keys are stored in `.env.local` (gitignored) and only accessed in server-side API routes (`src/app/api/`). The browser never sees the keys. The pipeline endpoint runs entirely on the server — the client receives only story text and audio bytes.
+
+### Rate Limiting
+
+In-memory rate limiter in `src/lib/rateLimit.ts`:
+
+| Setting | Default | Configurable Via |
+|---------|---------|-----------------|
+| Max requests per IP | 10 | `RATE_LIMIT_MAX` env var |
+| Window duration | 60 seconds | `RATE_LIMIT_WINDOW_MS` env var |
+| Scope | Shared across all endpoints | — |
+| Response | 429 with `retryAfter` in seconds | — |
+
+### Input Validation
+
+Every request is validated in `src/lib/validation.ts` before any external API call:
+
+| Field | Rule |
+|-------|------|
+| `month` | Integer 1-12 |
+| `day` | Integer 1-31 |
+| `genre` | Must exactly match one of 20 curated genres (or omitted) |
+| TTS `text` | Non-empty, max 5,000 characters |
+
+### HTTP Security Headers
+
+Deployed via `vercel.json`:
+
+| Header | Value | Purpose |
+|--------|-------|---------|
+| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains; preload` | Forces HTTPS for 2 years |
+| `X-Content-Type-Options` | `nosniff` | Prevents MIME-type sniffing |
+| `X-Frame-Options` | `DENY` | Blocks iframe embedding |
+| `X-XSS-Protection` | `1; mode=block` | Browser XSS filter |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | Limits referrer data leakage |
+| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | Disables unused browser APIs |
+| `Content-Security-Policy` | `default-src 'self'; connect-src 'self' https://api.anthropic.com` | Restricts resource loading |
+
+---
+
+## Cost Model
+
+### Per-Request Breakdown
+
+| Component | What It Costs | Typical Cost |
+|-----------|--------------|-------------|
+| **Claude Haiku 4.5** — input (~700 tokens) | $1.00 / 1M tokens | $0.0007 |
+| **Claude Haiku 4.5** — output (~300 tokens) | $5.00 / 1M tokens | $0.0015 |
+| **Claude total** | | **~$0.0022** |
+| **ElevenLabs Flash v2.5** (~1,150 chars) | ~$0.11 / 1K chars (Creator plan) | **~$0.13** |
+| **Background music** | Static asset | **$0.00** |
+| **Total per story** | | **~$0.13** |
+
+### Cost Drivers
+
+- **ElevenLabs dominates cost** — TTS is ~98% of per-request spend
+- **System prompt is fixed overhead** — ~640 of ~700 input tokens are identical every request. Anthropic's prompt caching can reduce this by 90%
+- **Genre adds only ~50 tokens** — negligible cost impact
+- **Shorter stories (150-200 words) save on both APIs** — fewer output tokens + fewer TTS characters
+
+### Client-Side Cost Display
+
+The pipeline returns `inputTokens`, `outputTokens`, and `ttsCharacters` in NDJSON events. `src/lib/costs.ts` calculates and formats the estimated cost, displayed in the StoryCard timing label.
+
+---
+
+## File Map
+
+Every source file with its purpose:
+
+| File | Purpose |
+|------|---------|
+| `src/app/page.tsx` | Main page — streaming pipeline orchestrator, state management, UI layout |
+| `src/app/layout.tsx` | Root layout — Geist fonts, global metadata |
+| `src/app/api/pipeline/route.ts` | Unified streaming endpoint — Claude story + ElevenLabs TTS in one NDJSON response |
+| `src/app/api/history/route.ts` | Standalone story generation endpoint (fallback) |
+| `src/app/api/tts/route.ts` | Standalone text-to-speech endpoint (fallback) |
+| `src/components/CalendarPicker.tsx` | Date picker — react-day-picker with amber/stone dark theme |
+| `src/components/Collapsible.tsx` | Reusable accordion — interactive or locked mode, measured scrollHeight animation |
+| `src/components/LoadingState.tsx` | Multi-phase loading indicator — themed messages, live elapsed timers, locked Collapsible |
+| `src/components/StoryCard.tsx` | Story display — genre badge, audio controls, MLA citation, timing + cost, locked Collapsible |
+| `src/hooks/useBackgroundMusic.ts` | Voyagers! music — fade-in/out, warmUp, mute toggle, sync with narrator |
+| `src/hooks/useHistoryStory.ts` | Story state — fetchStory (standalone), startLoading/setResult/setErrorState (pipeline) |
+| `src/hooks/useTextToSpeech.ts` | TTS playback — warmUp, playBlob, speak, togglePlayPause, replay, download, cleanup |
+| `src/lib/costs.ts` | Cost estimation — Claude token pricing + ElevenLabs character pricing |
+| `src/lib/genres.ts` | 20 curated content genres + `getRandomGenre()` random selection |
+| `src/lib/loadingMessages.ts` | Themed loading phase messages — archive theme + Voyagers! theme |
+| `src/lib/prompts.ts` | Shared system prompt, `publish_vignette` tool definition, `STORY_MODEL` constant |
+| `src/lib/rateLimit.ts` | In-memory rate limiter — per-IP tracking, configurable window and max |
+| `src/lib/validation.ts` | Input validation — month, day, genre, monthName mapping, buildUserMessage |
+| `public/audio/chronostream-runner.mp3` | Voyagers!-themed background music (static asset, loops during narration) |
+| `vercel.json` | Security headers configuration (CSP, HSTS, X-Frame-Options, etc.) |
+| `vitest.config.ts` | Test configuration — jsdom environment, path aliases, React plugin |
+| `package.json` | Dependencies, scripts, pnpm packageManager declaration |
+| `tsconfig.json` | TypeScript configuration — strict mode, path aliases |
+| `next.config.ts` | Next.js configuration |
+| `postcss.config.mjs` | PostCSS configuration for Tailwind CSS 4 |
+
+### Test Files (13 files, 214 tests)
+
+| File | Tests | What It Covers |
+|------|-------|---------------|
+| `useBackgroundMusic.test.ts` | 36 | Audio source, warmUp, fade-in/out timing, mute toggle, cleanup, page integration |
+| `StoryCard.test.tsx` | 36 | Story rendering, audio controls, genre badge, download, music toggle, locked accordion |
+| `Collapsible.test.tsx` | 20 | Interactive toggle, locked mode, aria attributes, chevron rotation, opacity transitions |
+| `validation.test.ts` | 18 | Month/day/genre validation, monthName mapping, buildUserMessage construction |
+| `ttsRoute.test.ts` | 16 | Voice ID (Adam), model (Flash v2.5), API URL, text validation, voice settings |
+| `issueTwoRegression.test.ts` | 16 | Loading UX guards, pipeline config, architecture regression tests |
+| `pipelineConfig.test.ts` | 16 | Pipeline models (Haiku + Flash), retired model guard, shared prompt content |
+| `rateLimit.test.ts` | 15 | Allow/block logic, per-IP tracking, window reset, concurrent request handling |
+| `LoadingState.test.tsx` | 14 | Phases, live timers, auto-expand/collapse, locked mode, themed messages |
+| `costs.test.ts` | 12 | Cost calculation accuracy, formatting, edge cases, token/character pricing |
+| `issueOneRegression.test.ts` | 10 | Architecture guards — warmUp, playBlob, pipeline helpers, handleEndedRef |
+| `loadingMessages.test.ts` | 10 | Message array integrity, pickRandom distribution, Voyagers! theme messages |
+| `genres.test.ts` | 5 | Genre list has 20 entries, all non-empty strings, getRandomGenre returns valid genre |
+
+---
+
+## Prompt Engineering
+
+The Claude system prompt (`src/lib/prompts.ts`) is a 400+ word instruction set built with the Kajiro IQ Pro methodology. It uses constraint-based prompting with four sections:
+
+| Section | Purpose | Key Rules |
+|---------|---------|-----------|
+| **Voice Rules** | Define the writing style | Second person, present tense, open with sensory detail, literary journalism |
+| **Factual Integrity** | Ensure historical accuracy | Real events only, no invented details, no unverified speculation |
+| **Structure** | Shape the narrative arc | One scene, build tension, resonant closing line, no moral lessons |
+| **Anti-Patterns** | Prevent common AI defaults | No encyclopedic openings, no bullet points, no meta-commentary |
+
+The `publish_vignette` tool schema forces Claude to return structured output:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `story` | string | 150-200 word creative nonfiction vignette |
+| `eventTitle` | string | Short title for the historical event |
+| `eventYear` | string | Year the event occurred |
+| `mlaCitation` | string | MLA 9th edition formatted citation |
+
+`tool_choice: { type: 'tool', name: 'publish_vignette' }` guarantees the tool is always called — Claude cannot respond with plain text.
+
+---
+
+## Deployment
+
+| Aspect | Configuration |
+|--------|--------------|
+| **Host** | Vercel |
+| **Build** | `pnpm build` (Next.js production build) |
+| **Environment** | `.env.local` with `ANTHROPIC_API_KEY` and `ELEVENLABS_API_KEY` |
+| **Domain** | Configured in Vercel dashboard |
+| **CI/CD** | Git push to `main` triggers automatic deployment |
+| **Branch protection** | `main` and `prod` require PRs; `dev` allows direct push |
+| **Package manager** | pnpm 10.32.1 (declared in `package.json` `packageManager` field) |
+
+---
+
+*Built with Kajiro IQ Pro | Kenneth Benavides | https://kajiro.org*

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -2,7 +2,7 @@
 
 **Author:** Kenneth Benavides
 **Built with:** Claude Code + Kajiro IQ Pro
-**Version:** MVP 8 (March 2026)
+**Version:** MVP 10 (March 2026)
 
 ---
 
@@ -27,7 +27,7 @@
 
 ## What This Project Is
 
-This Moment in History is an AI-powered creative nonfiction storytelling application with voice narration. You pick any calendar date. The app generates a vivid 150-200 word historical vignette -- not a Wikipedia summary, but an immersive second-person narrative that drops you into a real moment from the past. A narrator reads the story aloud over soft ambient piano music. The entire experience -- story, audio, music -- generates on demand in under 12 seconds.
+This Moment in History is an AI-powered creative nonfiction storytelling application with voice narration. You pick any calendar date. The app generates a vivid 150-200 word historical vignette -- not a Wikipedia summary, but an immersive second-person narrative that drops you into a real moment from the past. A narrator reads the story aloud over Voyagers!-themed background music. The entire experience -- story, audio, music -- generates on demand in under 12 seconds.
 
 Every story is grounded in historical fact. Every story is written like literary journalism. Every story comes with an event title, year, and MLA 9th edition citation.
 
@@ -43,7 +43,7 @@ Most "this day in history" apps give you a list of bullet points. A sentence abo
 
 This project started from a different premise: every date has a story worth *feeling*. Not as a list, but as a moment. The smell of gunpowder. The sound of a crowd. The weight of a decision made in a room with bad lighting. The AI system prompt enforces literary journalism rules -- sensory details, real people, real places, present tense, second person. The result reads like the opening paragraph of a magazine feature, not an encyclopedia entry.
 
-The technical goal was equally specific: build a production-quality AI application from zero to deployed in a 3-day sprint, using Claude Code and the Kajiro IQ Pro prompt optimization framework. What was estimated to take 8-11 hours was completed in approximately 6 hours across two evening sessions, shipping 8 MVPs with 92 passing tests.
+The technical goal was equally specific: build a production-quality AI application from zero to deployed in a 3-day sprint, using Claude Code and the Kajiro IQ Pro prompt optimization framework. What was estimated to take 8-11 hours was completed in approximately 8 hours across three evening sessions, shipping 10 MVPs with 214 passing tests.
 
 ---
 
@@ -53,11 +53,13 @@ The technical goal was equally specific: build a production-quality AI applicati
 |-----------|-------------|
 | **Date-Based Storytelling** | Pick any date from the calendar. Receive a historically accurate creative nonfiction vignette set on that date. |
 | **Voice Narration** | Every story is automatically narrated by Adam -- a deep, authoritative voice via ElevenLabs TTS. |
-| **Background Music** | Soft dreamscape piano loop plays during narration at 15% volume with a 2-second fade-in. |
+| **Voyagers! Music** | Chronostream Runner ambient soundtrack plays during narration at 12% volume with 2s fade-in and 3s fade-out. |
 | **Genre Discovery** | "Random History" picks a random date and applies one of 20 genre lenses (True Crime, Espionage, Science, Love, War, and 15 more). |
 | **Audio Controls** | Play/Pause, Replay from start, Download as MP3, Mute/Unmute background music. |
-| **Real-Time Timing** | Pipeline timing breakdown shows exactly how long story generation and audio generation take. |
+| **System-Controlled Accordion** | LoadingState and StoryCard persist in DOM with choreographed expand/collapse transitions -- no user toggle, system controls visibility. |
+| **Real-Time Timing + Cost** | Pipeline timing breakdown and per-request cost estimation (Claude tokens + ElevenLabs characters) displayed on every story. |
 | **Streaming Pipeline** | Unified server endpoint overlaps story and audio generation. Story displays while audio is still being created. |
+| **Themed Loading Messages** | Random archive-themed ("Searching the archives...") and Voyagers!-themed ("The Omni is locked on...") messages during generation. |
 | **Branding Outro** | Every audio file ends with the event title, date, year, and "This audio is created by This Moment in History. Copyright 2026." |
 
 ---
@@ -108,9 +110,13 @@ Flash v2.5 generates audio for a 150-word story in approximately 5-8 seconds ver
 | `similarity_boost` | 0.75 | Strong voice consistency across stories |
 | `style` | 0 | Disabled -- reduces latency with minimal audible difference for narrator-style speech |
 
-### Background Music: Static Asset
+### Background Music: Static Asset (Voyagers! Theme)
 
-**Why not generated per request:** The ambient piano loop is generated once via ElevenLabs Sound Effects API and saved as a static asset (`public/audio/ambient-bg.mp3`). This means zero per-request cost, zero latency, and consistent audio across sessions. The music loops infinitely at 15% volume -- subtle enough to enhance without distracting.
+**Why not generated per request:** The Chronostream Runner soundtrack is generated once via ElevenLabs Sound Effects API and saved as a static asset (`public/audio/chronostream-runner.mp3`). This means zero per-request cost, zero latency, and consistent audio across sessions. The music loops at 12% volume -- tuned for the fuller Voyagers!-themed orchestral track.
+
+**Why asymmetric fade:** Fade-in is 2 seconds, fade-out is 3 seconds. This mirrors broadcast audio practice -- listeners notice abrupt silence more than a slow swell. The longer fade-out creates a professional trail-off after the narration copyright outro finishes.
+
+**warmUp() for background music:** Like TTS, the background music Audio element must be created synchronously during a user click to satisfy browser autoplay policy. The `bgMusic.warmUp()` call in `page.tsx` runs in the same click handler as `tts.warmUp()`.
 
 ### Calendar: react-day-picker + date-fns
 
@@ -120,7 +126,7 @@ Flash v2.5 generates audio for a 150-word story in approximately 5-8 seconds ver
 
 ### Testing: Vitest + React Testing Library
 
-**Why Vitest over Jest:** Native TypeScript support, faster execution (2.5 seconds for 92 tests), and first-class Vite integration. The `jsdom` environment simulates browser APIs for component testing without a real browser.
+**Why Vitest over Jest:** Native TypeScript support, faster execution (2.5 seconds for 214 tests), and first-class Vite integration. The `jsdom` environment simulates browser APIs for component testing without a real browser.
 
 **Why React Testing Library:** Tests user-visible behavior, not implementation details. Tests query by text content ("Random History", "Pause"), not by CSS classes or component internals.
 
@@ -136,10 +142,12 @@ User clicks a date (or "Random History")
     v
 page.tsx: runPipeline(date, genre?)
     |
-    |-- tts.cleanup()           // Destroy previous audio
-    |-- bgMusic.stop()          // Stop previous music
-    |-- tts.warmUp()            // Create Audio element (autoplay policy)
-    |-- history.startLoading()  // Show "Uncovering history..."
+    |-- tts.cleanup()            // Destroy previous audio element + blob
+    |-- bgMusic.stop()           // Hard stop previous music
+    |-- tts.warmUp()             // Create TTS Audio element (autoplay policy)
+    |-- bgMusic.warmUp()         // Create bg Audio element (autoplay policy)
+    |-- history.startLoading()   // Set loading state
+    |-- setPhases([story, audio]) // Pick random themed loading messages
     |
     v
 fetch('/api/pipeline', { month, day, genre })
@@ -153,27 +161,33 @@ pipeline/route.ts (server):
     |-- Phase 1: Claude Haiku   // ~3-4 seconds
     |   |-- System prompt + tool_choice
     |   |-- Returns: story, eventTitle, eventYear, mlaCitation
-    |   |-- STREAM: {"type":"story", ...}\n  --> client displays story
+    |   |-- STREAM: {"type":"story", ..., inputTokens, outputTokens}\n
     |
     |-- Phase 2: ElevenLabs Flash  // ~5-8 seconds (starts immediately)
     |   |-- story + outro text --> audio bytes
-    |   |-- STREAM: {"type":"audio", "audio":"<base64>"}\n
+    |   |-- STREAM: {"type":"audio", "audio":"<base64>", ttsCharacters}\n
     |
     v
 page.tsx (client reads NDJSON stream):
     |
     |-- "story" event:
-    |   |-- history.setResult()      // Display story immediately
-    |   |-- tts.setLoadingState(true) // "Finding our history professor..."
+    |   |-- history.setResult()         // Display story immediately
+    |   |-- tts.setLoadingState(true)   // Show Voyagers!-themed message
+    |   |-- setCostData(tokens)         // Begin cost estimation
+    |   |-- LoadingState phase 1 closes, phase 2 opens
     |
     |-- "audio" event:
     |   |-- Decode base64 --> Blob
-    |   |-- tts.playBlob(blob)       // Auto-play narration
-    |   |-- bgMusic.play()           // Fade in ambient music
+    |   |-- tts.playBlob(blob)          // Auto-play narration
+    |   |-- bgMusic.play()              // Fade in Voyagers! music (2s)
+    |   |-- setCostData(chars)          // Complete cost estimation
+    |   |-- LoadingState auto-collapses, StoryCard auto-expands
     |
     v
-User hears narration with background music.
-Controls available: Play/Pause, Replay, Download, Mute Music, Random History.
+User hears narration with Voyagers! background music.
+    |-- When narration ends: bgMusic.fadeOut() (3s fade)
+    |-- Controls: Play/Pause, Replay, Download, Mute Music, Random History
+    |-- Timing + cost estimate displayed on StoryCard
 ```
 
 ### The NDJSON Streaming Protocol
@@ -226,6 +240,36 @@ cleanup()  --> .pause(), removeEventListener, revokeObjectURL, null refs
 ```
 
 The `handleEndedRef` pattern uses `useRef` for the event handler to maintain stable identity across renders. Without this, `addEventListener` and `removeEventListener` would receive different function references, causing ghost listeners that fire multiple times.
+
+### Background Music Lifecycle
+
+The `useBackgroundMusic` hook manages the Voyagers!-themed Chronostream Runner soundtrack:
+
+```
+warmUp()   --> getAudio() (lazy init, sets loop + preload + volume 0)
+play()     --> reset to start, fade from 0 to 12% over 2 seconds
+fadeOut()   --> fade from current volume to 0 over 3 seconds, then pause + reset
+stop()     --> immediate pause + reset (pipeline restart)
+pause()    --> pause without reset (sync with narrator pause)
+resume()   --> resume playback (sync with narrator resume)
+toggleMute() --> mute/unmute without affecting playback state
+```
+
+The asymmetric fade (2s in, 3s out) mirrors broadcast audio practice. Listeners notice abrupt silence more than a slow swell, so the fade-out is 50% longer than the fade-in.
+
+### System-Controlled UI Choreography
+
+LoadingState and StoryCard both use the `<Collapsible>` component in `locked` mode. This means:
+
+1. **Cards persist in DOM permanently** -- once mounted, they are never unmounted. Visibility is controlled entirely by the `expanded` prop, not by conditional rendering.
+2. **Headers are non-interactive** -- rendered as `<div>` elements instead of `<button>` elements. No user toggle, no cursor pointer, no click handler.
+3. **Expand/collapse is derived from props** -- `const expanded = autoExpand` in StoryCard, `const expanded = autoExpand && !autoCollapse` in LoadingState. No internal `useState` or `useEffect` for expand state.
+
+The choreography sequence:
+- Pipeline starts → LoadingState expands (shows loading phases)
+- Story arrives → LoadingState phase 1 closes, phase 2 opens
+- Audio arrives → LoadingState collapses, StoryCard expands
+- Both cards remain visible as collapsed headers when not active
 
 ---
 
@@ -339,7 +383,7 @@ Learn more: [https://kajiro.org](https://kajiro.org)
 
 ## The MVP Development Approach
 
-The project was built in 8 incremental MVPs, each adding a distinct capability layer. Every MVP was committed, tested, and pushed before the next began.
+The project was built in 10 incremental MVPs, each adding a distinct capability layer. Every MVP was committed, tested, and pushed before the next began.
 
 ### Why MVPs Matter
 
@@ -350,7 +394,7 @@ Each MVP produces a *working application*. If development stopped at MVP 1, you'
 - Forces clean interfaces (each layer must work with what exists)
 - Makes code review tractable (small, focused diffs)
 
-### The 8 Layers
+### The 10 Layers
 
 | MVP | Name | What It Added | Key Technical Decision |
 |-----|------|---------------|----------------------|
@@ -362,12 +406,14 @@ Each MVP produces a *working application*. If development stopped at MVP 1, you'
 | 6 | Autoplay Fix + Timing | Browser autoplay compliance + timers | `warmUp()` pattern + `useRef` for timing |
 | 7 | Efficiency Review | Bug fixes + code cleanup | `handleEndedRef` identity fix, dead prop removal |
 | 8 | Streaming Pipeline | NDJSON streaming + faster models | Server-side overlap, Haiku + Flash |
+| 9 | Voyagers! Music | Themed soundtrack + cost estimation | Asymmetric fade, bgMusic warmUp, themed loading messages |
+| 10 | System-Controlled Accordion | Persistent DOM cards + locked Collapsible | Derived state from props, non-interactive headers |
 
 ### How Each Layer Built on the Last
 
-MVP 1 established the data model (story + metadata). MVP 2 consumed that data model for narration. MVP 3 synced with MVP 2's playback events. MVP 4 extended MVP 1's API with genre support. MVP 5 unified MVPs 1-4 into an automatic pipeline. MVP 6 fixed a browser-level bug from MVP 5. MVP 7 cleaned up technical debt from MVPs 1-6. MVP 8 replaced the sequential architecture from MVP 5 with a streaming pipeline.
+MVP 1 established the data model (story + metadata). MVP 2 consumed that data model for narration. MVP 3 synced with MVP 2's playback events. MVP 4 extended MVP 1's API with genre support. MVP 5 unified MVPs 1-4 into an automatic pipeline. MVP 6 fixed a browser-level bug from MVP 5. MVP 7 cleaned up technical debt from MVPs 1-6. MVP 8 replaced the sequential architecture from MVP 5 with a streaming pipeline. MVP 9 replaced the ambient piano with the Voyagers!-themed Chronostream Runner and added cost transparency. MVP 10 introduced the locked Collapsible pattern and made cards persist in the DOM permanently.
 
-Each MVP's interface contract was preserved. `StoryCard` still accepts the same props it has since MVP 6. `useTextToSpeech` still exposes `speak()` even though the pipeline now uses `playBlob()`. Backward compatibility was maintained at every layer.
+Each MVP's interface contract was preserved. `StoryCard` still accepts the same props it has since MVP 6 (plus `autoExpand` from MVP 10). `useTextToSpeech` still exposes `speak()` even though the pipeline now uses `playBlob()`. Backward compatibility was maintained at every layer.
 
 ---
 
@@ -413,17 +459,23 @@ Deployed via `vercel.json`:
 
 ## Testing Strategy
 
-### 92 Tests Across 7 Test Files
+### 214 Tests Across 13 Test Files
 
 | File | Tests | What It Covers |
 |------|-------|----------------|
+| `useBackgroundMusic.test.ts` | 36 | Audio source, warmUp, fade-in/out timing, mute toggle, cleanup, page integration |
+| `StoryCard.test.tsx` | 36 | Story rendering, audio controls, genre badge, download, music toggle, locked accordion |
+| `Collapsible.test.tsx` | 20 | Interactive toggle, locked mode, aria attributes, chevron rotation, opacity transitions |
 | `validation.test.ts` | 18 | Input validation for month, day, genre. Month name mapping. User message construction with and without genre. |
-| `rateLimit.test.ts` | 5 | Allow/block logic, per-IP tracking, window reset after expiration. |
-| `StoryCard.test.tsx` | 29 | Story rendering, date formatting, event title/year display, MLA citation, genre badge, all audio controls (play/pause/replay/download), music mute toggle, timing label, spinning state. |
-| `LoadingState.test.tsx` | 5 | Default message, custom message, skeleton lines, elapsed timer with startTime, no timer without startTime. |
-| `genres.test.ts` | 5 | Genre list has 20 entries, all are non-empty strings, `getRandomGenre()` returns a valid genre. |
-| `ttsRoute.test.ts` | 16 | Voice ID matches Adam, model is Flash v2.5, API URL construction, text validation (empty, null, whitespace, length limits), voice settings ranges. |
-| `pipelineConfig.test.ts` | 14 | Pipeline models (Haiku + Flash), shared system prompt content (voice rules, tense, anti-patterns, word count), vignette tool schema (name, required fields, property types). |
+| `ttsRoute.test.ts` | 16 | Voice ID (Adam), model (Flash v2.5), API URL, text validation, voice settings |
+| `issueTwoRegression.test.ts` | 16 | Loading UX guards, pipeline config, architecture regression tests |
+| `pipelineConfig.test.ts` | 16 | Pipeline models (Haiku + Flash), retired model guard, shared prompt content |
+| `rateLimit.test.ts` | 15 | Allow/block logic, per-IP tracking, window reset, concurrent request handling |
+| `LoadingState.test.tsx` | 14 | Phases, live timers, auto-expand/collapse, locked mode, themed messages |
+| `costs.test.ts` | 12 | Cost calculation accuracy, formatting, edge cases, token/character pricing |
+| `issueOneRegression.test.ts` | 10 | Architecture guards -- warmUp, playBlob, pipeline helpers, handleEndedRef |
+| `loadingMessages.test.ts` | 10 | Message array integrity, pickRandom distribution, Voyagers! theme messages |
+| `genres.test.ts` | 5 | Genre list integrity, random selection |
 
 ### Testing Philosophy
 
@@ -458,7 +510,7 @@ Configuration tests verify that hardcoded constants match expected values -- cat
 ```bash
 git clone https://github.com/SeasonalHawk/this-moment-in-history.git
 cd this-moment-in-history
-npm install
+pnpm install
 ```
 
 Create `.env.local`:
@@ -471,9 +523,9 @@ ELEVENLABS_API_KEY=your-elevenlabs-key
 ### Run
 
 ```bash
-npm run dev        # Start development server on http://localhost:3000
-npm test           # Run all 92 tests
-npm run build      # Production build
+pnpm dev           # Start development server on http://localhost:3000
+pnpm test          # Run all 214 tests
+pnpm build         # Production build
 ```
 
 ### Optional Configuration
@@ -516,9 +568,10 @@ Edit `src/lib/prompts.ts` for the system prompt, or the model string in:
 
 ### Replace Background Music
 
-1. Replace `public/audio/ambient-bg.mp3` with your audio file
+1. Replace `public/audio/chronostream-runner.mp3` with your audio file
 2. Ensure it loops cleanly (the `<audio>` element has `loop: true`)
-3. Adjust `TARGET_VOLUME` in `src/hooks/useBackgroundMusic.ts` if needed
+3. Adjust `TARGET_VOLUME` in `src/hooks/useBackgroundMusic.ts` (currently 0.12 for the fuller orchestral track -- simpler tracks may work better at higher volumes)
+4. Test fade-in/out durations -- `FADE_IN_MS` and `FADE_OUT_MS` may need tuning for different track characters
 
 ---
 
@@ -547,6 +600,14 @@ Claude's `tool_use` with `tool_choice` guarantees typed JSON output. No regex pa
 ### 6. MVPs Compound
 
 Each MVP took less time than the one before because the interfaces were already defined. MVP 8 (streaming pipeline) reused the same `StoryCard` component from MVP 1, the same `useTextToSpeech` hook from MVP 2, and the same validation logic from MVP 1. The hooks just gained new methods (`playBlob`, `setLoadingState`) without breaking existing ones.
+
+### 7. Persistent DOM Beats Conditional Rendering for Animated Components
+
+MVP 10 revealed that conditionally rendering components (`{loading && <LoadingState />}`) causes them to unmount and lose all animation state. When the component remounts, it flashes -- no smooth transition, no collapsed header, just a jarring pop-in. Keeping components in the DOM permanently and controlling visibility via props (locked Collapsible, `autoExpand`) produces polished transitions without flash-of-unmount bugs. The cost is trivial -- a few hidden DOM nodes.
+
+### 8. Asymmetric Fade Durations Mirror Broadcast Practice
+
+Fade-in and fade-out don't need to be symmetrical. The Voyagers! music uses 2 seconds fade-in but 3 seconds fade-out. Listeners notice abrupt silence more than a slow swell, so the fade-out is 50% longer. This small asymmetry creates a noticeably more professional audio experience -- the music trails off gracefully after the narration copyright outro instead of cutting abruptly.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,7 +22,7 @@ The core finding: **This Moment in History occupies a genuinely uncontested mark
 5. [Image Generation API Evaluation](#image-generation-api-evaluation)
 6. [Recommended Image Generation Strategy](#recommended-image-generation-strategy)
 7. [Monetization Strategy](#monetization-strategy)
-8. [MVP 9 Scope Recommendation](#mvp-9-scope-recommendation)
+8. [Shipped Features (MVP 9-10)](#shipped-features-mvp-9-10)
 9. [Long-Term Vision](#long-term-vision)
 
 ---
@@ -95,11 +95,12 @@ Features that **no competitor offers in combination**:
 1. **AI-generated immersive narratives** — 2nd-person, present-tense literary journalism (vs. encyclopedic bullet points)
 2. **20 genre/tone options** — True Crime, Espionage, Love & Romance, etc. History through different lenses
 3. **Server-streamed pipeline** — Story + audio in one streaming NDJSON request with server-side overlap
-4. **Background music** — Atmospheric audio layer synced with narration
+4. **Voyagers!-themed soundtrack** — Chronostream Runner ambient music with professional fade-in/out synced with narration
 5. **Audio download** — Export narration as MP3 with branding outro
 6. **MLA citations** — Academic-grade sourcing on every story
 7. **Random discovery** — Genre-randomized exploration across dates
-8. **Pipeline performance metrics** — Real-time timing breakdown visible to users
+8. **Per-request cost transparency** — Real-time timing and cost estimation displayed on every story
+9. **System-controlled UI choreography** — Polished expand/collapse transitions with persistent DOM cards
 
 ---
 
@@ -244,52 +245,79 @@ Based on competitive analysis of pricing in the space:
 
 ---
 
-## MVP 9 Scope Recommendation
+## Shipped Features (MVP 9-10)
 
-Based on the Tier 1 feature analysis and technical feasibility, the recommended MVP 9 scope is:
+MVP 9 and 10 diverged from the original plan above. Instead of image generation and social sharing, the focus shifted to audio polish, cost transparency, and UI choreography — features that strengthen the core experience before adding new media layers.
 
-### MVP 9 — Visual History + Social Sharing
+### MVP 9 — Voyagers! Music + Cost Estimation (SHIPPED)
 
-| Feature | Implementation | Effort |
-|---------|---------------|:------:|
-| **Image generation** | Flux 2 Pro via fal.ai in streaming pipeline (parallel with TTS) | 4-6 hrs |
-| **Social sharing** | Open Graph meta tags + "Share" button generating story card image | 2-3 hrs |
-| **PWA manifest** | `manifest.json` + service worker for home-screen install | 1-2 hrs |
-| **User favorites** | localStorage bookmarks with favorites gallery page | 2-3 hrs |
-| **Estimated total** | | **~10-14 hrs** |
+| Feature | What Shipped |
+|---------|-------------|
+| **Voyagers! soundtrack** | Replaced dreamscape piano with Chronostream Runner — a fuller, themed ambient track |
+| **Background music warmUp** | Fixed browser autoplay for bg music with same warmUp() pattern as TTS |
+| **Professional fade-in/out** | 2s fade-in, 3s fade-out (asymmetric — mirrors broadcast practice) |
+| **Themed loading messages** | Random archive-themed and Voyagers!-themed messages during generation |
+| **Per-request cost estimation** | Claude token count + ElevenLabs character count → real-time cost displayed on card |
+| **209 tests passing** | +115 new tests covering music, costs, loading messages, regression guards |
 
-### MVP 9 Success Criteria
+### MVP 10 — System-Controlled Collapsible Accordion (SHIPPED)
 
-- [ ] Image generates for every story within 5 seconds
-- [ ] Image displays between story text and audio playback
-- [ ] Social share generates OG image with story excerpt
-- [ ] PWA installable on mobile (home screen icon)
-- [ ] Favorites persist across sessions via localStorage
-- [ ] All existing 94+ tests still pass
-- [ ] New tests cover image pipeline and favorites
+| Feature | What Shipped |
+|---------|-------------|
+| **Reusable Collapsible component** | `locked` mode for system-controlled expand/collapse, interactive mode for general use |
+| **Persistent DOM cards** | LoadingState and StoryCard never unmount — visibility controlled by props |
+| **Derived state from props** | `const expanded = autoExpand` — no internal useState, no sync bugs |
+| **Non-interactive headers** | Locked headers render as `<div>` not `<button>` — prevents premature clicks |
+| **Smooth transitions** | maxHeight + opacity via measured scrollHeight, works with dynamic content |
+| **214 tests passing** | +5 tests for locked Collapsible mode, updated StoryCard/LoadingState tests |
+
+### What Changed vs. Original Plan
+
+| Originally Planned for MVP 9 | Actual Status | Why |
+|-------------------------------|--------------|-----|
+| Image generation (Flux 2 Pro) | Moved to MVP 11 | Core audio experience needed polish first |
+| Social sharing (OG tags) | Moved to MVP 11 | Better to share with images when they exist |
+| PWA manifest | Moved to MVP 11 | Low-hanging fruit saved for image MVP |
+| User favorites (localStorage) | Moved to MVP 12 | Requires user accounts for cross-device sync |
+
+### What's Next: MVP 11+
+
+Based on the current state (10 MVPs, 214 tests, polished audio + UI), the highest-impact next features are:
+
+| MVP | Focus | Key Features |
+|-----|-------|-------------|
+| **11** | **Visual History** | Image generation (Flux 2 Pro via fal.ai, parallel with TTS in NDJSON pipeline), loading carousel with crossfading AI-generated artwork, social sharing (Open Graph images + share button), PWA manifest |
+| **12** | **Engagement** | User favorites (localStorage → cloud sync), daily notification/digest, podcast RSS feed auto-generation |
+| **13** | **Scale** | User accounts, gamification (streaks, quizzes), timeline visualization of explored dates |
+| **14+** | **Monetization** | Freemium tiers, classroom/education tools, public API, multi-language support |
 
 ---
 
 ## Long-Term Vision
 
-### Phase 1: Foundation (MVP 9-10)
-- Image generation pipeline
-- Social sharing + viral growth
-- PWA + mobile install
-- User favorites (localStorage)
+### Phase 1: Foundation (MVP 1-10) -- COMPLETE
+- Core storytelling engine with 20 genre lenses
+- Streaming pipeline (Claude Haiku + ElevenLabs Flash)
+- Voyagers!-themed background music with professional fade-in/out
+- System-controlled UI choreography (persistent DOM, locked Collapsible)
+- Per-request cost transparency
+- 214 tests across 13 files
 
-### Phase 2: Engagement (MVP 11-12)
-- Daily notification/digest system
+### Phase 2: Visual + Viral (MVP 11-12)
+- Image generation pipeline (Flux 2 Pro, parallel with TTS)
+- Loading carousel with crossfading AI-generated artwork
+- Social sharing (OG images, share buttons)
+- PWA manifest + home-screen install
+- User favorites + daily notifications
 - Auto-generated podcast RSS feed
-- Gamification (daily quiz, streaks)
-- Timeline visualization of explored dates
 
-### Phase 3: Scale (MVP 13+)
+### Phase 3: Scale + Monetize (MVP 13+)
 - User accounts + cloud sync
+- Gamification (streaks, quizzes)
 - Multi-language support
 - Classroom/education tools
 - Public API for developers
-- Monetization (freemium + education tier)
+- Freemium monetization tiers
 
 ### The Vision
 


### PR DESCRIPTION
## Summary
- Promotes full documentation suite update (GUIDE.md, ROADMAP.md, ARCHITECTURE.md) to production
- All four documentation files now current with MVP 10

## Test plan
- [x] `pnpm test` — 214 tests passing
- [x] `pnpm build` — clean production build
- [x] Documentation-only changes


🤖 Generated with [Claude Code](https://claude.com/claude-code)